### PR TITLE
Merging jiuqi-dev into master

### DIFF
--- a/experiment/discounted_train.py
+++ b/experiment/discounted_train.py
@@ -65,7 +65,7 @@ def _init_save_dir(save_dir: str) -> None:
 def _save_log(log: dict, save_dir: str) -> None:
     for key, value in log.items():
         log[key] = np.array(value)
-    np.savez(os.path.join(save_dir, 'discounted_train.npz'), **log)
+    np.savez(os.path.join(save_dir, 'data.npz'), **log)
 
 
 def train(d: int,

--- a/experiment/plotter.py
+++ b/experiment/plotter.py
@@ -9,9 +9,9 @@ from experiment.utils import compare_P, compare_Q, check_params, stack_four_np
 def load_data(data_dir):
     """Load data from specified directory and return the relevant metrics."""
 
-    with open(os.path.join(data_dir, 'discounted_train.pkl'), 'rb') as train_file, \
+    with np.load(os.path.join(data_dir, 'data.npz')) as data, \
          open(os.path.join(data_dir, 'params.json'), 'r') as params_file:
-        log = pickle.load(train_file)
+        log = {key: data[key] for key in data}
         params = json.load(params_file)  # Assuming params is used somewhere else
 
     return log, params


### PR DESCRIPTION
Key Update: the P and Q matrices are now of shape (T, L, 2*d+1, 2*d+1), where T is the number of logged steps and L is the layer number. This applies to BOTH autoregressive and sequential modes for consistency. Therefore, some plotting functions that work on a single pair of {P, Q} may break due to this change.
I refactored the print_final_weights method to work for this change.
1. cleaned up the training function a bit to modularize the functionalities
2. all experiment data are now NumPy arrays for ease of indexing in future plotting
3. save experimental data as .npz files for efficiency and compatibility since all data are numpy arrays
